### PR TITLE
enable-readline support in sqlite3 cli tool

### DIFF
--- a/build-sqlite
+++ b/build-sqlite
@@ -14,7 +14,7 @@ fetch_if_needed() {
 
 build() {
   cd sqlite
-  ./configure
+  ./configure --enable-readline
 
   if [ ! -v PREBUILT ]; then
     make -j$(nproc)

--- a/make-linux
+++ b/make-linux
@@ -22,7 +22,7 @@ install_prerequisites() {
   sudo apt-get install libboost-dev g++ libboost-filesystem-dev \
     libboost-program-options-dev libboost-regex-dev \
     libboost-system-dev libboost-test-dev \
-    libssl-dev libtool bison flex pkg-config
+    libssl-dev libtool bison flex pkg-config libreadline-dev libncurses-dev
 
   # Install prereqs based on https://github.com/apache/arrow/tree/master/cpp
   sudo apt-get install cmake \


### PR DESCRIPTION
Hi,

I was finding using the sqlite3 tool with out any command history really tedious, so here is a PR that enables readline support in sqlite3.

Thanks

Darren